### PR TITLE
Remove unused namespace

### DIFF
--- a/tests/Fast404MiddlewareTest.php
+++ b/tests/Fast404MiddlewareTest.php
@@ -3,7 +3,6 @@
 namespace PHPWatch\Fast404\Tests;
 
 use PHPWatch\Fast404\Fast404Middleware;
-use PHPUnit\Framework\TestCase;
 
 class Fast404MiddlewareTest extends TestCaseBase {
     public function testInstance(): void {


### PR DESCRIPTION
# Changed log

- Remove `PHPUnit\Framework\TestCase` namespace because it's declared, but not used.