### PR TITLE
Migrate PHPUnit configuration for the PHPUnit 9.x

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          executionOrder="depends,defects"
          forceCoversAnnotation="false"
@@ -16,14 +16,18 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+        </include>
+        <report>
+            <html outputDirectory="build/coverage-html"/>
+            <text outputFile="php://stdout" showUncoveredFiles="false"/>
+        </report>
+    </coverage>
 
     <logging>
-        <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-        <log type="coverage-html" target="build/coverage-html"/>
+        <text outputFile="php://stdout"/>
+        <testdoxHtml outputFile="build/coverage-html"/>
     </logging>
 </phpunit>


### PR DESCRIPTION
When running the `XDEBUG_MODE=coverage vendor/bin/phpunit` command, it presents the following warning message:

```
PHPUnit 9.5.26 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.13
Configuration: /data/Fast404/phpunit.xml.dist
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

......                                                              6 / 6 (100%)

Time: 00:00.015, Memory: 6.00 MB
```

To resolve above issue, it's time to change the `phpunit.xml.dist` file and change the configuration format for the PHPUnit 9.x now.